### PR TITLE
Minor change in script

### DIFF
--- a/Hospital_Mortality_SQL_Analysis.sql
+++ b/Hospital_Mortality_SQL_Analysis.sql
@@ -124,16 +124,17 @@ FROM patient_survival.ps_data;
 
 -- What was the percentage of patients with each comorbidity among those who died? 
 SELECT
-    ROUND(SUM(CASE WHEN aids = 1 THEN 1 ELSE 0 END) * 100 / COUNT(*),2) AS aids_percentage,
-    ROUND(SUM(CASE WHEN cirrhosis = 1 THEN 1 ELSE 0 END) * 100 / COUNT(*),2) AS cirrhosis_percentage,
-    ROUND(SUM(CASE WHEN diabetes_mellitus = 1 THEN 1 ELSE 0 END) * 100 / COUNT(*),2) AS diabetes_percentage,
-    ROUND(SUM(CASE WHEN hepatic_failure = 1 THEN 1 ELSE 0 END) * 100 / COUNT(*),2) AS hepatic_failure_percentage,
-    ROUND(SUM(CASE WHEN immunosuppression = 1 THEN 1 ELSE 0 END) * 100 / COUNT(*),2) AS immunosuppression_percentage,
-    ROUND(SUM(CASE WHEN leukemia = 1 THEN 1 ELSE 0 END) * 100 / COUNT(*),2) AS leukemia_percentage,
-    ROUND(SUM(CASE WHEN lymphoma = 1 THEN 1 ELSE 0 END) * 100 / COUNT(*),2) AS lymphoma_percentage,
-    ROUND(SUM(CASE WHEN solid_tumor_with_metastasis = 1 THEN 1 ELSE 0 END) * 100 / COUNT(*),2) AS solid_tumor_percentage
+    ROUND(SUM(CASE WHEN aids = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS aids_percentage,
+    ROUND(SUM(CASE WHEN cirrhosis = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS cirrhosis_percentage,
+    ROUND(SUM(CASE WHEN diabetes_mellitus = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS diabetes_percentage,
+    ROUND(SUM(CASE WHEN hepatic_failure = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS hepatic_failure_percentage,
+    ROUND(SUM(CASE WHEN immunosuppression = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS immunosuppression_percentage,
+    ROUND(SUM(CASE WHEN leukemia = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS leukemia_percentage,
+    ROUND(SUM(CASE WHEN lymphoma = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS lymphoma_percentage,
+    ROUND(SUM(CASE WHEN solid_tumor_with_metastasis = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) AS solid_tumor_percentage
 FROM patient_survival.ps_data
 WHERE hospital_death = 1;
+
 
 -- What is the mortality rate in percentage? 
 SELECT
@@ -207,10 +208,11 @@ GROUP BY bmi_category;
 -- Hospital death probabilities where the ICU type is 'SICU' and BMI is above 30
 SELECT
     patient_id,
-    apache_4a_hospital_death_prob as hospital_death_prob
+    apache_4a_hospital_death_prob AS hospital_death_prob
 FROM patient_survival.ps_data
 WHERE icu_type = 'SICU' AND bmi > 30
 ORDER BY hospital_death_prob DESC;
+
 
 
 


### PR DESCRIPTION
 descriptions for each of the SQL queries you provided:

Query 1: Percentage of Comorbidities Among Deceased Patients
This query calculates the percentage of patients who have specific comorbidities (like AIDS, cirrhosis, diabetes mellitus, etc.) among those who have deceased (hospital_death = 1). Each percentage is rounded to two decimal places, representing the proportion of deceased patients with each comorbidity.

Query 2: Patient Count by BMI Category
This query counts the number of patients categorized by their BMI into groups: 'Underweight', 'Normal', 'Overweight', and 'Obese'. It uses a subquery to calculate the BMI for each patient (excluding those with NULL BMI values), rounds the BMI to two decimal places, and then groups patients based on their BMI category.

Query 3: Patients in SICU with BMI Over 30 Ordered by Hospital Death Probability
This query selects patient_id and apache_4a_hospital_death_prob from the ps_data table for patients in a Surgical ICU (SICU) with a BMI greater than 30. The results are sorted in descending order by hospital_death_prob, providing a list of patients in SICU with higher predicted probabilities of hospital death due to their condition and BMI status.

Each query serves a specific analytical purpose, from assessing comorbidity prevalence among deceased patients to categorizing patients by BMI and predicting hospital outcomes based on ICU type and BMI thresholds.